### PR TITLE
fix(maven): use new feature names in pom.xml

### DIFF
--- a/camunda-bpm-karaf-feature/pom.xml
+++ b/camunda-bpm-karaf-feature/pom.xml
@@ -85,8 +85,8 @@
 								<descriptor>file://${project.basedir}/target/classes/features.xml</descriptor>
 							</descriptors>
 							<features>
-								<feature>camunda-engine-karaf-feature-minimal</feature>
-								<feature>camunda-engine-karaf-feature-full</feature>
+								<feature>camunda-bpm-karaf-feature-minimal</feature>
+								<feature>camunda-bpm-karaf-feature-full</feature>
 							</features>
 							<repository>target/features-repo</repository>
 						</configuration>


### PR DESCRIPTION
Just a typo but required for a successful build: the feature names should also be changed in the feature/pom.xml
