### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/camunda-bpm-karaf-feature/src/main/resources/features.xml
+++ b/camunda-bpm-karaf-feature/src/main/resources/features.xml
@@ -19,7 +19,7 @@
     <bundle>mvn:org.apache.juli/com.springsource.org.apache.juli.extras/6.0.24</bundle>
     <bundle>mvn:org.apache.commons/commons-email/1.3.2</bundle>
     <bundle>mvn:org.apache.ant/com.springsource.org.apache.tools.ant/1.7.1</bundle>
-    <bundle>mvn:commons-collections/commons-collections/3.2.1</bundle>
+    <bundle>mvn:commons-collections/commons-collections/3.2.2</bundle>
     <bundle>mvn:commons-beanutils/commons-beanutils/1.9.1</bundle>
   </feature>
 

--- a/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/AbstractOSGiELResolverIntegrationTest.java
+++ b/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/AbstractOSGiELResolverIntegrationTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractOSGiELResolverIntegrationTest extends
     mavenBundle().groupId("commons-beanutils")
         .artifactId("commons-beanutils").version("1.9.1"),
     mavenBundle().groupId("commons-collections")
-        .artifactId("commons-collections").version("3.2.1"));
+        .artifactId("commons-collections").version("3.2.2"));
 		return OptionUtils.combine(beanUtils, super.createConfiguration());
 	}
 


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/