### PR TITLE
Support for TaskListener and Activity behaviours in blueprint-/ OSGI- el-resolver

### DIFF
--- a/camunda-bpm-blueprint-wrapper/src/test/java/org/camunda/bpm/extension/osgi/blueprint/BlueprintELResolverTest.java
+++ b/camunda-bpm-blueprint-wrapper/src/test/java/org/camunda/bpm/extension/osgi/blueprint/BlueprintELResolverTest.java
@@ -9,8 +9,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.DelegateTask;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.impl.juel.SimpleContext;
+import org.camunda.bpm.engine.impl.pvm.delegate.ActivityBehavior;
+import org.camunda.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.camunda.bpm.extension.osgi.blueprint.BlueprintELResolver;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +51,30 @@ public class BlueprintELResolverTest {
 				"delegate");
 		assertThat(object, is(nullValue()));
 	}
+
+  @Test
+  public void bindTaskListenerService() {
+    Map<String, String> props = new HashMap<String, String>();
+    props.put(OSGI_SERVICE_BLUEPRINT_COMPNAME, "taskListener");
+    MockTaskListener taskListener = new MockTaskListener();
+    resolver.bindTaskListenerService(taskListener, props);
+    SimpleContext context = new SimpleContext();
+    Object object = resolver.getValue(context, null, "taskListener");
+    assertThat(object == taskListener, is(true));
+    assertThat(context.isPropertyResolved(), is(true));
+  }
+
+  @Test
+  public void bindActivityBehaviourService() {
+    Map<String, String> props = new HashMap<String, String>();
+    props.put(OSGI_SERVICE_BLUEPRINT_COMPNAME, "activityBehaviour");
+    MockActivityBehaviour activityBehaviour = new MockActivityBehaviour();
+    resolver.bindActivityBehaviourService(activityBehaviour, props);
+    SimpleContext context = new SimpleContext();
+    Object object = resolver.getValue(context, null, "activityBehaviour");
+    assertThat(object == activityBehaviour, is(true));
+    assertThat(context.isPropertyResolved(), is(true));
+  }
 
 	@Test
 	public void getValueWithNullProperty() {
@@ -112,7 +140,7 @@ public class BlueprintELResolverTest {
 	public void unbindServiceWithEmptyProperties() {
 		resolver.unbindService(new MockDelegate(), new HashMap<Object, Object>());
 	}
-	
+
 	@Test
 	public void unbindService(){
 		Map<String, String> props = new HashMap<String, String>();
@@ -126,9 +154,47 @@ public class BlueprintELResolverTest {
 		assertThat(context.isPropertyResolved(), is(false));
 	}
 
+  @Test
+  public void unbindTaskListenerService(){
+    Map<String, String> props = new HashMap<String, String>();
+    props.put(OSGI_SERVICE_BLUEPRINT_COMPNAME, "taskListener");
+    MockTaskListener taskListener = new MockTaskListener();
+    resolver.bindTaskListenerService(taskListener, props);
+    resolver.unbindTaskListenerService(taskListener, props);
+    SimpleContext context = new SimpleContext();
+    Object value = resolver.getValue(context, null, "taskListener");
+    assertThat(value, is(nullValue()));
+    assertThat(context.isPropertyResolved(), is(false));
+  }
+
+  @Test
+  public void unbindActivityBehaviourService(){
+    Map<String, String> props = new HashMap<String, String>();
+    props.put(OSGI_SERVICE_BLUEPRINT_COMPNAME, "activityBehaviour");
+    MockActivityBehaviour activityBehaviour = new MockActivityBehaviour();
+    resolver.bindActivityBehaviourService(activityBehaviour, props);
+    resolver.unbindActivityBehaviourService(activityBehaviour, props);
+    SimpleContext context = new SimpleContext();
+    Object value = resolver.getValue(context, null, "activityBehaviour");
+    assertThat(value, is(nullValue()));
+    assertThat(context.isPropertyResolved(), is(false));
+  }
+
 	private class MockDelegate implements JavaDelegate {
 		@Override
 		public void execute(DelegateExecution execution) throws Exception {
 		}
 	}
+
+	private class MockTaskListener implements TaskListener {
+    @Override
+    public void notify(DelegateTask delegateTask) {
+    }
+  }
+
+  private class MockActivityBehaviour implements ActivityBehavior {
+    @Override
+    public void execute(ActivityExecution execution) throws Exception {
+    }
+  }
 }

--- a/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/JustAnotherTaskListener.java
+++ b/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/JustAnotherTaskListener.java
@@ -1,0 +1,14 @@
+package org.camunda.bpm.extension.osgi.itest.el;
+
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.TaskListener;
+
+public class JustAnotherTaskListener implements TaskListener {
+
+  public boolean called = false;
+
+  @Override
+  public void notify(DelegateTask delegateTask) {
+    this.called = true;
+  }
+}

--- a/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/OSGIELResolverTaskListenerTest.java
+++ b/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/OSGIELResolverTaskListenerTest.java
@@ -1,0 +1,36 @@
+package org.camunda.bpm.extension.osgi.itest.el;
+
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+import java.io.File;
+import java.util.Hashtable;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class OSGIELResolverTaskListenerTest extends AbstractOSGiELResolverIntegrationTest{
+  @Override
+  protected File getProcessDefinition() {
+    return new File("src/test/resources/el/testTaskListener.bpmn");
+  }
+
+  @Test
+  public void runProcess() throws Exception {
+    JustAnotherTaskListener service = new JustAnotherTaskListener();
+    ctx.registerService(TaskListener.class, service, null);
+    ProcessInstance processInstance = processEngine.getRuntimeService()
+      .startProcessInstanceByKey("taskListenerTestProcess");
+    assertThat(service.called, is(true));
+  }
+}

--- a/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/OSGiELResolverTaskListenerTest.java
+++ b/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/OSGiELResolverTaskListenerTest.java
@@ -1,10 +1,6 @@
 package org.camunda.bpm.extension.osgi.itest.el;
 
-import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.engine.delegate.TaskListener;
-import org.camunda.bpm.engine.runtime.ProcessInstance;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -12,24 +8,23 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerMethod;
 
 import java.io.File;
-import java.util.Hashtable;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
-public class OSGIELResolverTaskListenerTest extends AbstractOSGiELResolverIntegrationTest{
+public class OSGiELResolverTaskListenerTest extends AbstractOSGiELResolverIntegrationTest {
   @Override
   protected File getProcessDefinition() {
     return new File("src/test/resources/el/testTaskListener.bpmn");
   }
 
   @Test
-  public void runProcess() throws Exception {
+  public void runProcess() {
     JustAnotherTaskListener service = new JustAnotherTaskListener();
     ctx.registerService(TaskListener.class, service, null);
-    ProcessInstance processInstance = processEngine.getRuntimeService()
+    processEngine.getRuntimeService()
       .startProcessInstanceByKey("taskListenerTestProcess");
     assertThat(service.called, is(true));
   }

--- a/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/OSGiELTenantIntegrationTest.java
+++ b/camunda-bpm-osgi-itest/src/test/java/org/camunda/bpm/extension/osgi/itest/el/OSGiELTenantIntegrationTest.java
@@ -1,0 +1,135 @@
+package org.camunda.bpm.extension.osgi.itest.el;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.impl.cfg.StandaloneProcessEngineConfiguration;
+import org.camunda.bpm.engine.repository.DeploymentBuilder;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.extension.osgi.el.OSGiExpressionManager;
+import org.camunda.bpm.extension.osgi.engine.ProcessEngineFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Hashtable;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class OSGiELTenantIntegrationTest extends AbstractOSGiELResolverIntegrationTest {
+
+  protected void deployProcessDefinition() {
+    File subProcess = new File("src/test/resources/testprocess.bpmn");
+    File tenantSpecificSubprocess = new File("src/test/resources/el/tenantSpecificProcess.bpmn");
+    File processDef = new File("src/test/resources/el/tenantParentProcess.bpmn");
+    DeploymentBuilder builder = processEngine.getRepositoryService()
+      .createDeployment();
+    builder.name(getClass().getName());
+    try {
+      // deploy the default parent process  and the default subprocess (tenant = null)
+      builder
+        .addInputStream(processDef.getName(), new FileInputStream(processDef))
+        .addInputStream(subProcess.getName(), new FileInputStream(subProcess))
+        .deploy();
+
+      // deploy the tenant specific subprocess in a separate deployment
+      processEngine.getRepositoryService()
+        .createDeployment()
+        .addInputStream(tenantSpecificSubprocess.getName(), new FileInputStream(tenantSpecificSubprocess))
+        .tenantId("t1")
+        .deploy();
+
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void createProcessEngine() {
+    StandaloneProcessEngineConfiguration configuration = new StandaloneProcessEngineConfiguration();
+    configuration.setDatabaseSchemaUpdate("create-drop")
+      .setDataSource(createDatasource())
+      .setJobExecutorActivate(false);
+    configuration.setExpressionManager(new OSGiExpressionManager());
+    ProcessEngineFactory processEngineFactory = new ProcessEngineFactory();
+    processEngineFactory.setProcessEngineConfiguration(configuration);
+    processEngineFactory
+      .setBundle(getBundle("org.camunda.bpm.extension.osgi"));
+    try {
+      processEngineFactory.init();
+      processEngine = processEngineFactory.getObject();
+      ctx.registerService(ProcessEngine.class.getName(), processEngine,
+        new Hashtable<String, String>());
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+  }
+
+  @Test
+  public void tenantSubprocessShouldBeResolved() throws InterruptedException {
+    Hashtable<String, String> properties = new Hashtable<String, String>();
+    properties.put("processExpression", "calledElementTenantIdProvider");
+    MockedCalledElementTenantIdProvider service = new MockedCalledElementTenantIdProvider("t1");
+    ctx.registerService(MockedCalledElementTenantIdProvider.class, service, properties);
+
+    RuntimeService runtimeService = processEngine.getRuntimeService();
+    runtimeService.startProcessInstanceByKey("tenantParentProcess");
+
+    ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery()
+      .processDefinitionKey("Process_1").singleResult();
+    assertThat(processInstance.isEnded(), is(false));
+    Task task = processEngine.getTaskService().createTaskQuery().singleResult();
+    assertThat(task.getName(), is("specific tenant task"));
+  }
+
+  @Test
+  public void defaultSubprocessShouldBeResolvedForNullTenant() throws InterruptedException {
+    Hashtable<String, String> properties = new Hashtable<String, String>();
+    properties.put("processExpression", "calledElementTenantIdProvider");
+    MockedCalledElementTenantIdProvider service = new MockedCalledElementTenantIdProvider(null);
+    ctx.registerService(MockedCalledElementTenantIdProvider.class, service, properties);
+
+    RuntimeService runtimeService = processEngine.getRuntimeService();
+    runtimeService.createProcessInstanceByKey("tenantParentProcess")
+      .execute();
+
+    // check if default sub process is called (tenant id = null)
+    ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery()
+      .processDefinitionKey("Process_1").singleResult();
+
+    assertNull(subProcessInstance.getTenantId());
+  }
+
+  @Override
+  protected File getProcessDefinition() {
+    return null; // null here because we override deployProcessDefinition
+  }
+
+  /**
+   * mock in order to return a "calculated" tenantId at runtime - when calling the subprocess
+   * inside tenantParentProcess.bpmn
+   */
+  private class MockedCalledElementTenantIdProvider {
+    private String tenantToReturn;
+
+    public MockedCalledElementTenantIdProvider(String tenantToReturn) {
+      this.tenantToReturn = tenantToReturn;
+    }
+
+    public String resolveTenantId(DelegateExecution execution) {
+      return this.tenantToReturn;
+    }
+
+    public String getTenantToReturn() {
+      return tenantToReturn;
+    }
+  }
+}

--- a/camunda-bpm-osgi-itest/src/test/resources/blueprint/context.xml
+++ b/camunda-bpm-osgi-itest/src/test/resources/blueprint/context.xml
@@ -61,11 +61,24 @@
 	<service ref="managementService" interface="org.camunda.bpm.engine.ManagementService" />
 	<!-- ############ End BPM services ############ -->
 
-	<reference-list id="activityProviders" availability="optional"
+  <!-- ### if you are using the BlueprintELResolver configure the bind / unbind methods -->
+	<reference-list id="delegateProviders" availability="optional"
 		interface="org.camunda.bpm.engine.delegate.JavaDelegate" activation="eager">
 		<reference-listener ref="blueprintELResolver"
 			bind-method="bindService" unbind-method="unbindService" />
 	</reference-list>
+
+  <reference-list id="taskListenerProviders" availability="optional"
+                  interface="org.camunda.bpm.engine.delegate.TaskListener" activation="eager">
+    <reference-listener ref="blueprintELResolver" bind-method="bindTaskListenerService"
+                        unbind-method="unbindTaskListenerService"/>
+  </reference-list>
+
+  <reference-list id="activityProviders" availability="optional"
+                  interface="org.camunda.bpm.engine.impl.pvm.delegate.ActivityBehavior" activation="eager">
+    <reference-listener ref="blueprintELResolver" bind-method="bindActivityBehaviourService"
+                        unbind-method="unbindActivityBehaviourService"/>
+  </reference-list>
 
 </blueprint>
 

--- a/camunda-bpm-osgi-itest/src/test/resources/el/tenantParentProcess.bpmn
+++ b/camunda-bpm-osgi-itest/src/test/resources/el/tenantParentProcess.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_14w3gob" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.13.0">
+  <bpmn:process id="tenantParentProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1q4w1f5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1q4w1f5" sourceRef="StartEvent_1" targetRef="Task_012j9ft" />
+    <bpmn:endEvent id="EndEvent_02ahr79">
+      <bpmn:incoming>SequenceFlow_1oka5hk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1oka5hk" sourceRef="Task_012j9ft" targetRef="EndEvent_02ahr79" />
+    <bpmn:callActivity id="Task_012j9ft" name="test" calledElement="Process_1" camunda:calledElementTenantId="${calledElementTenantIdProvider.resolveTenantId(execution)}">
+      <bpmn:incoming>SequenceFlow_1q4w1f5</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oka5hk</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="tenantParentProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q4w1f5_di" bpmnElement="SequenceFlow_1q4w1f5">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="259" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="189" y="99" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_02ahr79_di" bpmnElement="EndEvent_02ahr79">
+        <dc:Bounds x="409" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="427" y="142" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oka5hk_di" bpmnElement="SequenceFlow_1oka5hk">
+        <di:waypoint x="359" y="120" />
+        <di:waypoint x="409" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="99" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_1yq2ejc_di" bpmnElement="Task_012j9ft">
+        <dc:Bounds x="259" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/camunda-bpm-osgi-itest/src/test/resources/el/tenantSpecificProcess.bpmn
+++ b/camunda-bpm-osgi-itest/src/test/resources/el/tenantSpecificProcess.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_14w3gob" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.13.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1q4w1f5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1q4w1f5" sourceRef="StartEvent_1" targetRef="Task_012j9ft" />
+    <bpmn:endEvent id="EndEvent_02ahr79">
+      <bpmn:incoming>SequenceFlow_1oka5hk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1oka5hk" sourceRef="Task_012j9ft" targetRef="EndEvent_02ahr79" />
+    <bpmn:userTask id="Task_012j9ft" name="specific tenant task">
+      <bpmn:incoming>SequenceFlow_1q4w1f5</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oka5hk</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q4w1f5_di" bpmnElement="SequenceFlow_1q4w1f5">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="259" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="189" y="99" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_02ahr79_di" bpmnElement="EndEvent_02ahr79">
+        <dc:Bounds x="409" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="427" y="142" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oka5hk_di" bpmnElement="SequenceFlow_1oka5hk">
+        <di:waypoint x="359" y="120" />
+        <di:waypoint x="409" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="99" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1vp7hth_di" bpmnElement="Task_012j9ft">
+        <dc:Bounds x="259" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/camunda-bpm-osgi-itest/src/test/resources/el/testTaskListener.bpmn
+++ b/camunda-bpm-osgi-itest/src/test/resources/el/testTaskListener.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_14w3gob" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.13.0">
+  <bpmn:process id="taskListenerTestProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1q4w1f5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1q4w1f5" sourceRef="StartEvent_1" targetRef="Task_012j9ft" />
+    <bpmn:endEvent id="EndEvent_02ahr79">
+      <bpmn:incoming>SequenceFlow_1oka5hk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1oka5hk" sourceRef="Task_012j9ft" targetRef="EndEvent_02ahr79" />
+    <bpmn:userTask id="Task_012j9ft" name="test">
+      <bpmn:extensionElements>
+        <camunda:taskListener delegateExpression="${justAnotherTaskListener}" event="create" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1q4w1f5</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oka5hk</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="taskListenerTestProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q4w1f5_di" bpmnElement="SequenceFlow_1q4w1f5">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="259" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="189" y="99" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_02ahr79_di" bpmnElement="EndEvent_02ahr79">
+        <dc:Bounds x="409" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="427" y="142" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oka5hk_di" bpmnElement="SequenceFlow_1oka5hk">
+        <di:waypoint x="359" y="120" />
+        <di:waypoint x="409" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="99" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0q32hr6_di" bpmnElement="Task_012j9ft">
+        <dc:Bounds x="259" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/camunda-bpm-osgi/src/main/java/org/camunda/bpm/extension/osgi/el/OSGiELResolver.java
+++ b/camunda-bpm-osgi/src/main/java/org/camunda/bpm/extension/osgi/el/OSGiELResolver.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.impl.javax.el.BeanELResolver;
 import org.camunda.bpm.engine.impl.javax.el.ELContext;
 import org.camunda.bpm.engine.impl.pvm.delegate.ActivityBehavior;
@@ -32,8 +33,13 @@ public class OSGiELResolver extends BeanELResolver {
           returnValue = checkRegisteredOsgiServices(JavaDelegate.class, key);
         }
         if (returnValue == null) {
-          // finally ActivitiBehaviors
+          // go on with ActivitiBehaviors
           returnValue = checkRegisteredOsgiServices(ActivityBehavior.class, key);
+        }
+
+        if (returnValue == null) {
+          // finally TaskListeners
+          returnValue = checkRegisteredOsgiServices(TaskListener.class, key);
         }
       } catch (InvalidSyntaxException e) {
         throw new RuntimeException(e);
@@ -57,7 +63,7 @@ public class OSGiELResolver extends BeanELResolver {
   /**
    * Checks the OSGi ServiceRegistry if a service matching the given filter is
    * present.
-   * 
+   *
    * @param filter
    *          the LDAP filter
    * @return null if no service could be found or the service object
@@ -86,7 +92,7 @@ public class OSGiELResolver extends BeanELResolver {
    * <code>
    * public class MyServiceTask extends JavaDelegate</code> <br/>
    * matches {@link JavaDelegate} with key "myServiceTask".
-   * 
+   *
    * @param serviceClazz
    * @param key
    *          the name of the class
@@ -113,7 +119,7 @@ public class OSGiELResolver extends BeanELResolver {
    * Gets the service objects from the {@link BundleContext} and compares the
    * class names to the given key. For the comparison see
    * {@link #checkRegisteredOsgiServices(String, String)}.
-   * 
+   *
    * @param references
    * @param key
    * @return

--- a/camunda-bpm-osgi/src/test/java/org/camunda/bpm/extension/osgi/el/OSGiELResolverTest.java
+++ b/camunda-bpm-osgi/src/test/java/org/camunda/bpm/extension/osgi/el/OSGiELResolverTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.impl.javax.el.ELContext;
 import org.camunda.bpm.engine.impl.javax.el.MethodNotFoundException;
 import org.camunda.bpm.engine.impl.javax.el.PropertyNotFoundException;
@@ -149,6 +150,43 @@ public class OSGiELResolverTest {
     ServiceReference<ActivityBehavior> reference1 = mockService(behaviour1);
     ServiceReference<ActivityBehavior> reference2 = mockService(behaviour2);
     registerServiceRefsAtContext(ActivityBehavior.class, null, reference1, reference2);
+    resolver.getValue(elContext, null, lookupName);
+  }
+
+  @Test
+  public void getValueForSingleTaskService() throws InvalidSyntaxException {
+    String lookupName = "testTaskListener";
+    TaskListener serviceObject = new TestTaskListener();
+    ServiceReference<TaskListener> reference = mockService(serviceObject);
+    registerServiceRefsAtContext(TaskListener.class, null, reference);
+    TaskListener value = (TaskListener) resolver.getValue(elContext, null, lookupName);
+    assertThat(value, is(sameInstance(serviceObject)));
+    wasPropertyResolved();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void getValueForTwoTaskServices() throws InvalidSyntaxException {
+    String lookupName = "testTaskListener";
+    TaskListener serviceObject = new TestTaskListener();
+    TaskListener anotherServiceObject = mock(TaskListener.class);
+    ServiceReference<TaskListener> reference1 = mockService(serviceObject);
+    ServiceReference<TaskListener> reference2 = mockService(anotherServiceObject);
+    registerServiceRefsAtContext(TaskListener.class, null, reference1, reference2);
+    TaskListener value = (TaskListener) resolver.getValue(elContext, null, lookupName);
+    assertThat(value, is(sameInstance(serviceObject)));
+    wasPropertyResolved();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test(expected = RuntimeException.class)
+  public void getValueForTaskServicesWithSameName() throws InvalidSyntaxException {
+    String lookupName = "testTaskListener";
+    TaskListener behaviour1 = new TestTaskListener();
+    TaskListener behaviour2 = new TestTaskListener();
+    ServiceReference<TaskListener> reference1 = mockService(behaviour1);
+    ServiceReference<TaskListener> reference2 = mockService(behaviour2);
+    registerServiceRefsAtContext(TaskListener.class, null, reference1, reference2);
     resolver.getValue(elContext, null, lookupName);
   }
 

--- a/camunda-bpm-osgi/src/test/java/org/camunda/bpm/extension/osgi/el/TestTaskListener.java
+++ b/camunda-bpm-osgi/src/test/java/org/camunda/bpm/extension/osgi/el/TestTaskListener.java
@@ -1,0 +1,11 @@
+package org.camunda.bpm.extension.osgi.el;
+
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.TaskListener;
+
+public class TestTaskListener implements TaskListener {
+  @Override
+  public void notify(DelegateTask delegateTask) {
+
+  }
+}


### PR DESCRIPTION
Hi Ronny,

thanks a lot for your detailled answers in the last few months. I have enabled the TaskListener -Support for the OSGI-EL-Resolver, Support for TaskListener, Activity Behaviours in the blueprint el resolver and related tests. Also i have added an Integration test for calling a tenant specific subprocess, where the tenant id is dynamically resolved at runtime, when calling the subprocess through a "Call Activity" Task.

Cheers, 
Andy